### PR TITLE
fix mysql port seen as string instead of int

### DIFF
--- a/prometheus_mysql_exporter/__init__.py
+++ b/prometheus_mysql_exporter/__init__.py
@@ -154,7 +154,7 @@ def main():
     for name, (interval, query, value_columns) in queries.items():
         mysql_client = MySQLdb.connect(
             host = mysql_host,
-            port = mysql_port,
+            port = int(mysql_port),
             user = username,
             passwd = password,
             autocommit = True,


### PR DESCRIPTION
I had this issue with mysql client and custom port : 

> [2016-09-19 12:08:32,654] root.INFO MainThread Starting server...
> [2016-09-19 12:08:32,656] root.INFO MainThread Server started on port 8080
> Traceback (most recent call last):
>   File "/usr/local/bin/prometheus-mysql-exporter", line 9, in <module>
>     load_entry_point('prometheus-mysql-exporter', 'console_scripts', 'prometheus-mysql-exporter')()
>   File "/usr/src/app/prometheus_mysql_exporter/__init__.py", line 160, in main
>     autocommit = True,
>   File "/usr/local/lib/python3.5/site-packages/MySQLdb/__init__.py", line 81, in Connect
>     return Connection(*args, **kwargs)
>   File "/usr/local/lib/python3.5/site-packages/MySQLdb/connections.py", line 204, in __init__
>     super(Connection, self).__init__(*args, **kwargs2)
> TypeError: an integer is required (got type str)