### PR TITLE
Convert user supplied mysql ports to integers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='prometheus-mysql-exporter',
-    version='0.1.0',
+    version='0.1.1',
     description='MySQL query Prometheus exporter',
     url='https://github.com/Braedon/prometheus-mysql-exporter',
     author='Braedon Vickers',


### PR DESCRIPTION
The MySQL connection requires the port as an integer, so previously user
supplied ports didn't work.