### PR TITLE
Rework how databases to query are configured

### DIFF
--- a/exporter.cfg
+++ b/exporter.cfg
@@ -5,5 +5,6 @@
 # other columns will be used a labels.
 [query_test]
 QueryIntervalSecs = 5
+QueryDatabase = test
 QueryStatement = SELECT bar, baz, count(*) as ni, max(ekki) as ptang FROM foo GROUP BY bar, baz;
 QueryValueColumns = ni,ptang

--- a/prometheus_mysql_exporter/parser.py
+++ b/prometheus_mysql_exporter/parser.py
@@ -20,6 +20,10 @@ def parse_response(query_name, db_name, value_columns, response):
     result = []
 
     for row in response:
+        # NOTE: This db label isn't strictly necessary, since a single query can
+        #       only be run on a single database. It's retained for backwards
+        #       compatibility with previous versions that allowed queries to be
+        #       run on multiple databases.
         labels = {'db': db_name}
         labels.update({column: str(row[column])
                        for column in row


### PR DESCRIPTION
Drop the --mysql-databases cli option. This allowed running _all_ queries
against multiple databases. While this was helpful in cases where there
were multiple databases with identical table setups, it didn't allow
running different queries on different databases.

It was also fragile - if different databases had slightly different
columns for tables being queried, it was easy to accidentally produce
metrics with the same name but different label keys, with unexpected
results.

It's more flexible (and safer) to instead configure a single database per
query via the exporter.cfg file. If the same queries need to be run against
multiple databases, they can be duplicated (with different query names).