### PR TITLE
Reconnect after a broken Mysql Server is available again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     install_requires=[
         'click',
         'click-config-file',
+        'cryptography',
         'DBUtils ~= 1.3',
         'jog',
         'PyMySQL',


### PR DESCRIPTION
Hi,

for me here 0.4.2 does not reconnect after a mysql server has gone away and returned.

However, I found out that after installing the _cryptography_ module, it started working